### PR TITLE
 tidb: Fix kill server failed when --username isn't root

### DIFF
--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -212,9 +212,11 @@
       )
     )
     (teardown! [_ test node]
-      (info node "tearing down TiDB")
-      (stop! test node)
-      ; (c/exec :rm :-rf tidb-dir)
+      (c/su
+        (info node "tearing down TiDB")
+        (stop! test node)
+        ; (c/exec :rm :-rf tidb-dir)
+      )
     )
 
     db/LogFiles


### PR DESCRIPTION
As "installing TiDB" process is wrapped with `c/su`, and "tearing down TiDB" is not.
So when run test with `--username noroot`  will setup server with root user, and teardown server with noroot user,the latter process will fail.