### PR TITLE
support init connections by abitrary sql

### DIFF
--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -466,7 +466,11 @@
     :validate [#{:repeatable-read :read-committed} "Must be one of 'repeatable-read', 'read-committed'"]]
 
    [nil "--follower-read" "whether to open follower read"
-    :default false]])
+    :default false]
+
+   [nil "--init-sql STMTS", "SQL Statements to be executed for each connection"
+    :parse-fn #(->> (str/split % #";") (map str/trim) (drop-while empty))
+    :default nil]])
 
 (defn test-all-cmd
   "A command that runs a whole suite of tests in one go."


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

Example:
```sh
$JEPSEN_TEST --init-sql="set @@tidb_enable_async_commit = 1; set @@tidb_enable_1pc = 1, @@tidb_guarantee_external_consistency = 1;"
```