### PR TITLE
Port cockroach/comments to tidb

### DIFF
--- a/tidb/src/tidb/comments.clj
+++ b/tidb/src/tidb/comments.clj
@@ -1,0 +1,158 @@
+(ns tidb.comments
+  "Checks for a strict serializability anomaly in which T1 < T2, but T2 is
+  visible without T1.
+
+  We perform concurrent blind inserts across n tables, and meanwhile, perform
+  reads of both tables in a transaction. To verify, we replay the history,
+  tracking the writes which were known to have completed before the invocation
+  of any write w_i. If w_i is visible, and some w_j < w_i is *not* visible,
+  we've found a violation of strict serializability.
+
+  Splits keys up onto different tables to make sure they fall in different
+  shard ranges"
+  (:refer-clojure :exclude [test])
+  (:require [jepsen [client :as client]
+             [checker :as checker]
+             [core :as jepsen]
+             [generator :as gen]
+             [independent :as independent]
+             [util :as util :refer [meh]]]
+            [clojure.set :as set]
+            [clojure.tools.logging :refer :all]
+            [tidb.sql :as c :refer :all]
+            [tidb.basic :as basic]
+            [knossos.model :as model]
+            [knossos.op :as op]
+            [clojure.core.reducers :as r]))
+
+(def table-prefix "String prepended to all table names." "comment_")
+
+(defn table-names
+  "Names of all tables"
+  [table-count]
+  (map (partial str table-prefix) (range table-count)))
+
+(defn id->table
+  "Turns an id into a table id"
+  [table-count id]
+  (str table-prefix (mod (hash id) table-count)))
+
+(defrecord CommentsClient [table-count tbl-created? conn]
+  client/Client
+
+  (open! [this test node]
+    (assoc this :conn (c/open node test)))
+
+  (setup! [this test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (c/with-conn-failure-retry conn
+          (info "Creating tables" (pr-str (table-names table-count)))
+          (doseq [t (table-names table-count)]
+            (c/execute! conn [(str "create table " t
+                                   " (id int primary key,
+                                       tkey int)")])
+            (info "Created table" t))))))
+
+
+  (invoke! [this test op]
+    (case (:f op)
+      :write (let [[k id] (:value op)
+                   table (id->table table-count id)]
+               (c/insert! conn table {:id id, :tkey k})
+               (assoc op :type :ok))
+
+      :read (with-txn op [c conn {:isolation (get test :isolation :repeatable-read)}]
+              (->> (table-names table-count)
+                   (mapcat (fn [table]
+                             (c/query c [(str "select id from "
+                                              table
+                                              " where tkey = ?")
+                                         (key (:value op))])))
+                   (map :id)
+                   (into (sorted-set))
+                   (independent/tuple (key (:value op)))
+                   (assoc op :type :ok, :value)))))
+
+  (teardown! [this test]
+    nil)
+
+  (close! [this test]
+    (c/close! conn)))
+
+(defn checker
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      ; Determine first-order write precedence graph
+      (let [expected (loop [completed  (sorted-set)
+                            expected   {}
+                            [op & more :as history] history]
+                       (cond
+                         ; Done
+                         (not (seq history))
+                         expected
+
+                         ; We know this value is definitely written
+                         (= :write (:f op))
+                         (cond ; Write is beginning; record precedence
+                           (op/invoke? op)
+                           (recur completed
+                                  (assoc expected (:value op) completed)
+                                  more)
+
+                               ; Write is completing; we can now expect to see
+                               ; it
+                           (op/ok? op)
+                           (recur (conj completed (:value op))
+                                  expected more)
+
+                           true
+                           (recur completed expected more))
+
+                         true
+                         (recur completed expected more)))
+            errors (->> history
+                        (r/filter op/ok?)
+                        (r/filter #(= :read (:f %)))
+                        (reduce (fn [errors op]
+                                  (let [seen         (:value op)
+                                        our-expected (->> seen
+                                                          (map expected)
+                                                          (reduce set/union))
+                                        missing (set/difference our-expected
+                                                                seen)]
+                                    (if (empty? missing)
+                                      errors
+                                      (conj errors
+                                            (-> op
+                                                (dissoc :value)
+                                                (assoc :missing missing)
+                                                (assoc :expected-count
+                                                       (count our-expected)))))))
+                                []))]
+        {:valid? (empty? errors)
+         :errors errors}))))
+
+(defn reads [] {:type :invoke, :f :read, :value nil})
+(defn writes []
+  (->> (range)
+       (map (fn [k] {:type :invoke, :f :write, :value k}))
+       gen/seq))
+
+(defn workload
+  [opts]
+  (let [reads (reads)
+        writes (writes)]
+    {:name   "comments"
+     :client   (CommentsClient. 10 (atom false) nil)
+     :generator (independent/concurrent-generator
+                 (count (:nodes opts))
+                 (range)
+                 (fn [k]
+                   (->> (gen/mix [reads writes])
+                        (gen/stagger 1/100)
+                        (gen/limit 500))))
+     :checker (checker/compose
+               {:perf       (checker/perf)
+                :sequential (independent/checker (checker))})}))


### PR DESCRIPTION
The test is used to check the external consistency issue introduced by the async commit feature.

I'm not sure if I do it right. PTAL @zyguan @sticnarf 

But when setting `@@tidb_guarantee_external_consistency=0` I haven't been able to find a failure case.
