### PR TITLE
do not exec `apt update` when setup debian os

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -152,7 +152,7 @@
 
     (setup-hostfile!)
 
-    (maybe-update!)
+    ; (maybe-update!)
 
     (c/su
       ; Packages!


### PR DESCRIPTION
Since required packages are cached in image, there is no need for update package index. Besides, the unstable idc network may cause timeout of tests.

Signed-off-by: zyguan <zhongyangguan@gmail.com>