### PR TITLE
support failpoint nemesis

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -235,13 +235,14 @@
   :match-executable?
   :match-process-name?
   :pidfile
+  :env
   :process-name"
   [opts bin & args]
   (info "starting" (.getName (file (name bin))))
   (exec :echo (lit "`date +'%Y-%m-%d %H:%M:%S'`")
         "Jepsen starting" bin (escape args)
         :>> (:logfile opts))
-  (apply exec :start-stop-daemon :--start
+  (apply exec (map #(str (name (first %)) "=" (name (second %))) (:env opts)):start-stop-daemon :--start
          (when (:background? opts true) [:--background :--no-close])
          (when (:make-pidfile? opts true) :--make-pidfile)
          (when (:match-executable? opts true) [:--exec bin])

--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -152,7 +152,7 @@
 
     (setup-hostfile!)
 
-    ; (maybe-update!)
+    (maybe-update!)
 
     (c/su
       ; Packages!

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -160,6 +160,7 @@
     :shuffle-leader
     :shuffle-region
     :random-merge
+    :failpoint
     ; :clock-skew
     ; Special-case generators
     ; :slow-primary
@@ -280,6 +281,10 @@
                :color       "#A0C8E9"
                :start       #{:start-partition}
                :stop        #{:stop-partition}}
+              {:name        "failpoint"
+               :color       "#FFB266"
+               :start       #{:enable-failpoint}
+               :stop        #{:disable-failpoint}}
               ;{:name        "clock"
               ; :color       "#A0E9DB"
               ; :start       #{:strobe-clock :bump-clock}
@@ -312,7 +317,8 @@
                     (str " nemesis " (->> (dissoc (:nemesis opts)
                                                   :interval
                                                   :schedule
-                                                  :long-recovery)
+                                                  :long-recovery
+                                                  :failpoints)
                                           keys
                                           (map name)
                                           sort
@@ -363,6 +369,13 @@
        (map str/trim)
        (drop-while empty)))
 
+(defn parse-failpoints
+  [s]
+  (->> (str/split s #",")
+       (map str/trim)
+       (drop-while empty)
+       (map #(str/split % #":"))))
+
 (def cli-opts
   "Command line options for tools.cli"
   [[nil "--faketime MAX_RATIO"
@@ -397,6 +410,13 @@
     :parse-fn keyword
     :assoc-fn (fn [m k v] (update m :nemesis assoc :schedule v))
     :validate [#{:fixed :random} "Must be either 'fixed' or 'random'"]]
+
+   [nil "--failpoints FAILPOINTS" "List of failpoints to perform."
+    :parse-fn parse-failpoints
+    :assoc-fn (fn [m k v] (update m :nemesis assoc :failpoints v))
+    :validate [(fn [parsed]
+                 (every? #(= 3 (count %)) parsed))
+               "Should be a comma-seperated list like `tidb:tikvclient/rpcFailOnRecv:2%return,tikv:delay_update_max_ts:return`."]]
 
    ["-o" "--os NAME" "debian, centos, or none"
     :default debian/os

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -11,6 +11,7 @@
              [core :as jepsen]
              [generator :as gen]
              [os :as os]
+             [net :as net]
              [tests :as tests]
              [util :as util]]
             [jepsen.os.debian :as debian]
@@ -26,11 +27,19 @@
              [sets :as set]
              [table :as table]]))
 
+(deftype Image []
+  os/OS
+  (setup! [_ test node]
+          (info node "setting up prepared image")
+          (util/meh (net/heal! (:net test) test)))
+  (teardown! [_ test node]))
+
 (def oses
   "Supported operating systems"
   {"debian" debian/os
    "centos" centos/os
-   "none"   os/noop})
+   "none"   os/noop
+   "image"  (Image.)})
 
 (def workloads
   "A map of workload names to functions that can take CLI opts and construct

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -207,6 +207,7 @@
       {:logfile db-stdout
        :pidfile db-pid-file
        :chdir   tidb-dir
+       :env {:GO_FAILPOINTS "github.com/pingcap/tidb/server/enableTestAPI=return"}
        }
       (str "./bin/" db-bin)
       :--store     (str "tikv")

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -360,6 +360,7 @@
       (cu/install-archive! (tarball-url test) tidb-dir (:force-reinstall test))
       (info "Syncing disks to avoid slow fsync on db start")
       (c/exec :sync))
+      (info "Syncing disks done")
     ; (if-let [ratio (:faketime test)]
     ;   (do ; We need a special fork of faketime specifically for tikv, which
     ;       ; uses CLOCK_MONOTONIC_COARSE (not supported by 0.9.6 stock), and
@@ -418,11 +419,12 @@
       (c/su
         (install! test node)
         (configure!)
+        (jepsen/synchronize test 180)
 
         (try+ (start-wait-pd! test node)
               ; If we don't synchronize, KV might explode because PD isn't
               ; fully available
-              (jepsen/synchronize test 180)
+              (jepsen/synchronize test)
               (Thread/sleep 5000)
 
               (start-wait-kv! test node)

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -357,7 +357,7 @@
               (not (cu/exists? tidb-dir)))
       (info node "installing TiDB")
       (info (tarball-url test))
-      (cu/install-archive! (tarball-url test) tidb-dir (:force-reinstall test))
+      (cu/install-archive! (tarball-url test) tidb-dir)
       (info "Syncing disks to avoid slow fsync on db start")
       (c/exec :sync))
       (info "Syncing disks done")

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -390,7 +390,7 @@
   for it to do that before starting our tests if we want to be able to test
   things like failover. <sigh>"
   [node]
-  (loop [tries 1000]
+  (loop [tries 30]
     (when (zero? tries)
       (throw+ {:type :gave-up-waiting-for-replica-count}))
 

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -422,7 +422,7 @@
         (try+ (start-wait-pd! test node)
               ; If we don't synchronize, KV might explode because PD isn't
               ; fully available
-              (jepsen/synchronize test)
+              (jepsen/synchronize test 180)
               (Thread/sleep 5000)
 
               (start-wait-kv! test node)

--- a/tidb/src/tidb/util.clj
+++ b/tidb/src/tidb/util.clj
@@ -1,3 +1,37 @@
-(ns tidb.util)
+(ns tidb.util
+  (:require [clojure.string :as str]
+            [clj-http.client :as http]))
 
 (defn isolation-level [test] (get test :isolation :repeatable-read))
+
+(defn fail-api
+  ([node port]
+   (fail-api node port ""))
+  ([node port failpoint]
+   (str "http://" (name node) ":" port "/fail/" failpoint)))
+
+(defn fail-enabled?
+  [node port]
+  (= 200 (-> (fail-api node port)
+             (http/get {:throw-exceptions false})
+             (:status))))
+
+(defn fail-enable!
+  [node port failpoint value]
+  (-> (fail-api node port failpoint)
+      (http/put {:body value})))
+
+(defn fail-disable!
+  [node port failpoint]
+  (-> (fail-api node port failpoint)
+      (http/delete)))
+
+(defn fail-list
+  [node port]
+  (->> (fail-api node port)
+       (http/get)
+       (:body)
+       (str/split-lines)
+       (map #(str/split % #"=" 2))
+       (filter #(not (empty? (second %))))
+       (into {})))


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

Here is an example:
```
$ jepsen_workload=append
$ jepsen_tarball=http://fileserver.pingcap.net/.../tidb-master-failpoint.tar.gz
$ jepsen_nodes=...
$ lein run test --time-limit=300 --concurrency 2n --version=latest --tarball-url=$jepsen_tarball --force-reinstall --username=root --ssh-private-key manifests/local/ssh-key --nodes=$jepsen_nodes --os centos --workload=$jepsen_workload --txn-mode=pessimistic --read-lock=update \
  --nemesis=failpoint --failpoints=tidb:tikvclient/twoPCRequestBatchSizeLimit:50%return,tidb:tikvclient/commitFailedSkipCleanup:30%return,tidb:tikvclient/prewritePrimaryFail:2%return,tidb:tikvclient/rpcFailOnRecv:2%return,tikv:delay_update_max_ts:10%return
...
2021-08-26 04:50:29,084{GMT}	INFO	[jepsen worker 4-172.32.1.5] jepsen.util: 4	:ok	:txn	[[:append 18 5]]	{:txn_scope "global", :start_ts 427282511655600155, :commit_ts 427282511707766800, :txn_commit_mode "1pc", :async_commit_fallback false, :one_pc_fallback false}
2021-08-26 04:50:29,085{GMT}	INFO	[jepsen worker 4-172.32.1.5] jepsen.util: 4	:invoke	:txn	[[:r 20 nil] [:r 18 nil] [:append 17 7] [:append 17 8]]
2021-08-26 04:50:29,129{GMT}	INFO	[jepsen nemesis] jepsen.util: :nemesis	:info	:enable-failpoint	(["172.32.1.1" ([(10080 "tikvclient/prewritePrimaryFail" "2%return") :ok] [(10080 "tikvclient/rpcFailOnRecv" "2%return") :ok])] ["172.32.1.4" ([(10080 "tikvclient/twoPCRequestBatchSizeLimit" "50%return") :ok] [(10080 "tikvclient/rpcFailOnRecv" "2%return") :ok])] ["172.32.1.2" ([(10080 "tikvclient/rpcFailOnRecv" "2%return") :ok] [(10080 "tikvclient/commitFailedSkipCleanup" "30%return") :ok] [(20180 "delay_update_max_ts" "10%return") :ok] [(10080 "tikvclient/prewritePrimaryFail" "2%return") :ok])] ["172.32.1.3" ([(20180 "delay_update_max_ts" "10%return") :ok] [(10080 "tikvclient/rpcFailOnRecv" "2%return") :ok] [(10080 "tikvclient/twoPCRequestBatchSizeLimit" "50%return") :ok] [(10080 "tikvclient/commitFailedSkipCleanup" "30%return") :ok])])
...
2021-08-26 04:50:38,865{GMT}	WARN	[jepsen worker 1-172.32.1.2] jepsen.core: Process 1 crashed
java.sql.SQLException: (conn=7) injected error on prewriting primary batch
...
2021-08-26 04:50:48,370{GMT}	INFO	[jepsen nemesis] jepsen.util: :nemesis	:info	:disable-failpoint	(["172.32.1.1" ([(10080 "tikvclient/prewritePrimaryFail") :ok] [(10080 "tikvclient/rpcFailOnRecv") :ok])] ["172.32.1.2" ([(10080 "tikvclient/commitFailedSkipCleanup") :ok] [(10080 "tikvclient/prewritePrimaryFail") :ok] [(10080 "tikvclient/rpcFailOnRecv") :ok] [(20180 "delay_update_max_ts") :ok])] ["172.32.1.3" ([(10080 "tikvclient/commitFailedSkipCleanup") :ok] [(10080 "tikvclient/rpcFailOnRecv") :ok] [(10080 "tikvclient/twoPCRequestBatchSizeLimit") :ok] [(20180 "delay_update_max_ts") :ok])] ["172.32.1.4" ([(10080 "tikvclient/rpcFailOnRecv") :ok] [(10080 "tikvclient/twoPCRequestBatchSizeLimit") :ok])] ["172.32.1.5" ()])
2021-08-26 04:50:48,383{GMT}	INFO	[jepsen worker 6-172.32.1.2] jepsen.util: 16	:ok	:txn	[[:r 61 [1 3]] [:append 62 1]]	{:txn_scope "global", :start_ts 427282516675395593, :commit_ts 427282516767145993, :txn_commit_mode "1pc", :async_commit_fallback false, :one_pc_fallback false}
2021-08-26 04:50:48,383{GMT}	INFO	[jepsen worker 6-172.32.1.2] jepsen.util: 16	:invoke	:txn	[[:r 60 nil]]
...
```