### PR TITLE
do nothing on tearing down db

### DIFF
--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -166,6 +166,7 @@
         (try
           ; And however long it takes to run these
           (with-conn-failure-retry c
+            (j/execute! c ["update mysql.tidb set variable_value='72h' where variable_name='tikv_gc_life_time'"])
             (j/execute! c ["create table if not exists jepsen_await
                            (id int primary key, val int)"]))
             (j/insert! c "jepsen_await" {:id  (swap! await-id inc)


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

So that we can keep failure environment for further investigation, also allow us dumping mvcc after test automatically.