### PR TITLE
specify advertise-status-addr explicitly

### DIFF
--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -192,12 +192,13 @@
        :chdir   tidb-dir
        }
       (str "./bin/" kv-bin)
-      :--pd             (pd-endpoints test)
-      :--addr           (str "0.0.0.0:20160")
-      :--advertise-addr (str (name node) ":" "20160")
-      :--data-dir       kv-data-dir
-      :--log-file       kv-log-file
-      :--config         kv-config-file)))
+      :--pd                    (pd-endpoints test)
+      :--addr                  (str "0.0.0.0:20160")
+      :--advertise-addr        (str (name node) ":" "20160")
+      :--advertise-status-addr (str (name node) ":" "20180")
+      :--data-dir              kv-data-dir
+      :--log-file              kv-log-file
+      :--config                kv-config-file)))
 
 (defn start-db!
   "Starts the TiDB daemon"

--- a/tidb/src/tidb/monotonic.clj
+++ b/tidb/src/tidb/monotonic.clj
@@ -110,8 +110,7 @@
      :checker (checker/compose
                 {:cycle (cycle/checker
                           (cycle/combine cycle/monotonic-key-graph
-                                         cycle/realtime-graph
-                                         util/tso-graph))
+                                         cycle/realtime-graph))
                  :timeline (timeline/html)})
      :generator (->> (gen/mix [(incs key-count)
                                (reads key-count)]))}))
@@ -167,8 +166,7 @@
   {:client  (txn/client {:val-type "int"})
    :checker (cycle/checker
               (cycle/combine cycle/wr-graph
-                             cycle/realtime-graph
-                             util/tso-graph))
+                             cycle/realtime-graph))
    :generator (->> (wr-txns {:min-txn-length 2, :max-txn-length 5})
                    (map (fn [txn] {:type :invoke, :f :txn, :value txn}))
                    gen/seq)})
@@ -218,4 +216,4 @@
    :checker (append/checker {:anomalies         [(if (= :read-committed (:isolation opts)) :G1 :G-single)]
                              ; Jepsen may raise an IllegalStateException("Don't know how to classify") if a cycle only
                              ; consists of realtime edges and tso edges, which is typically caused by wrong tso info.
-                             :additional-graphs [cycle/realtime-graph util/tso-graph]})})
+                             :additional-graphs [cycle/realtime-graph]})})


### PR DESCRIPTION
also drop tso-graph checker since it's not compatible with tidb.