### PR TITLE
fix the way to enable tidb failpoint api

### DIFF
--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -207,7 +207,7 @@
       {:logfile db-stdout
        :pidfile db-pid-file
        :chdir   tidb-dir
-       :env {:GO_FAILPOINTS "github.com/pingcap/tidb/server/enableTestAPI=return"}
+       :env {:GO_FAILPOINTS "github.com/pingcap/tidb/pkg/server/enableTestAPI=return;github.com/pingcap/tidb/server/enableTestAPI=return"}
        }
       (str "./bin/" db-bin)
       :--store     (str "tikv")


### PR DESCRIPTION
adjust the failpoint path according to https://github.com/pingcap/tidb/pull/47123