### PR TITLE
Always enable autocommit before invoke an operation

### DIFF
--- a/tidb/project.clj
+++ b/tidb/project.clj
@@ -9,5 +9,6 @@
                  [cheshire "5.8.1"]
                  [org.clojars.pingcap/jepsen "0.1.15-SNAPSHOT"]
                  [org.clojure/java.jdbc "0.7.11"]
-                 [org.mariadb.jdbc/mariadb-java-client "2.4.1"]]
+                 [org.mariadb.jdbc/mariadb-java-client "2.4.1"]
+                 [javax.xml.bind/jaxb-api "2.3.1"]]
   :aot [tidb.core clojure.tools.logging.impl])

--- a/tidb/project.clj
+++ b/tidb/project.clj
@@ -9,6 +9,5 @@
                  [cheshire "5.8.1"]
                  [org.clojars.pingcap/jepsen "0.1.15-SNAPSHOT"]
                  [org.clojure/java.jdbc "0.7.11"]
-                 [org.mariadb.jdbc/mariadb-java-client "2.4.1"]
-                 [javax.xml.bind/jaxb-api "2.3.1"]]
+                 [org.mariadb.jdbc/mariadb-java-client "2.4.1"]]
   :aot [tidb.core clojure.tools.logging.impl])

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -94,7 +94,7 @@
   (open (::node conn) (::test conn)))
 
 (defn set-auto-commit!
-  "Set a JDBC connection's autocommit variable, will retry until success."
+  "Set a JDBC connection's autocommit variable."
   [conn auto-commit]
   (when-let [c (j/db-find-connection conn)]
     (.setAutoCommit c auto-commit)))

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -87,6 +87,12 @@
     (.close c))
   (dissoc conn :connection))
 
+(defn set-auto-commit!
+  "Set a JDBC connection's autocommit variable."
+  [conn auto-commit]
+  (when-let [c (j/db-find-connection conn)]
+    (.setAutoCommit c auto-commit)))
+
 (defn reopen!
   "Closes a connection and returns a new one based on the given connection."
   [conn]

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -87,17 +87,22 @@
     (.close c))
   (dissoc conn :connection))
 
-(defn set-auto-commit!
-  "Set a JDBC connection's autocommit variable."
-  [conn auto-commit]
-  (when-let [c (j/db-find-connection conn)]
-    (.setAutoCommit c auto-commit)))
-
 (defn reopen!
   "Closes a connection and returns a new one based on the given connection."
   [conn]
   (close! conn)
   (open (::node conn) (::test conn)))
+
+(defn set-auto-commit!
+  "Set a JDBC connection's autocommit variable, will retry until success."
+  [conn auto-commit]
+  (when-let [c (j/db-find-connection conn)]
+    (loop []
+      (try
+        (.setAutoCommit c auto-commit)
+        (catch Exception e
+          (info "Failed to set auto-commit, error" e "retrying...")
+          (Thread/sleep 100))))))
 
 (defn execute!
   "Like j/execute!, but provides a default timeout."

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -97,12 +97,7 @@
   "Set a JDBC connection's autocommit variable, will retry until success."
   [conn auto-commit]
   (when-let [c (j/db-find-connection conn)]
-    (loop []
-      (try
-        (.setAutoCommit c auto-commit)
-        (catch Exception e
-          (info "Failed to set auto-commit, error" e "retrying...")
-          (Thread/sleep 100))))))
+    (.setAutoCommit c auto-commit)))
 
 (defn execute!
   "Like j/execute!, but provides a default timeout."

--- a/tidb/src/tidb/txn.clj
+++ b/tidb/src/tidb/txn.clj
@@ -99,6 +99,7 @@
           (c/execute! conn [(str "alter table " (table-name i) " cache")])))))
 
   (invoke! [this test op]
+    (c/set-auto-commit! conn true)
     (let [txn (:value op)]
       (condp = (txn-type test table-count txn)
 


### PR DESCRIPTION
If the auto commit is set to false somewhere(e.g. missing error handling [here](https://github.com/clojure/java.jdbc/blob/36159f259cc51a1dcb9b64ea08f02f0e98c22b5e/src/main/clojure/clojure/java/jdbc.clj#L840-L841)), the single-stmt op will leave an opened transaction, and mistakenly used by the next op.

If the autocommit is set to true correctly, this function won't take any effect, [details](https://github.com/mariadb-corporation/mariadb-connector-j/blob/d148c7cd347c4680617be65d9e511b289d38a30b/src/main/java/org/mariadb/jdbc/MariaDbConnection.java#L734-L736).