### PR TITLE
Support new option --index-lookup-pushdown

### DIFF
--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -60,37 +60,40 @@
 (def workload-options
   "For each workload, a map of workload options to all values that option
   supports."
-  {:append          {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :read-lock         [nil "FOR UPDATE"]
-                     :predicate-read    [true false]}
-   :bank            {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :update-in-place   [true false]
-                     :read-lock         [nil "FOR UPDATE"]}
-   :bank-multitable {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :update-in-place   [true false]
-                     :read-lock         [nil "FOR UPDATE"]}
-   :comments        {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]}
-   :long-fork       {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :use-index         [true false]}
-   :monotonic       {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :use-index         [true false]}
-   :register        {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :read-lock         [nil "FOR UPDATE"]
-                     :use-index         [true false]}
-   :set             {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]}
-   :set-cas         {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]
-                     :read-lock         [nil "FOR UPDATE"]}
-   :sequential      {:auto-retry        [true false]
-                     :auto-retry-limit  [10 0]}
+  {:append          {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :read-lock             [nil "FOR UPDATE"]
+                     :predicate-read        [true false]}
+   :bank            {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :update-in-place       [true false]
+                     :read-lock             [nil "FOR UPDATE"]}
+   :bank-multitable {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :update-in-place       [true false]
+                     :read-lock             [nil "FOR UPDATE"]}
+   :comments        {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]}
+   :long-fork       {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :use-index             [true false]
+                     :index-lookup-pushdown [true false]}
+   :monotonic       {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :use-index             [true false]
+                     :index-lookup-pushdown [true false]}
+   :register        {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :read-lock             [nil "FOR UPDATE"]
+                     :use-index             [true false] 
+                     :index-lookup-pushdown [true false]}
+   :set             {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]}
+   :set-cas         {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]
+                     :read-lock             [nil "FOR UPDATE"]}
+   :sequential      {:auto-retry            [true false]
+                     :auto-retry-limit      [10 0]}
    :table           {}})
 
 (def workload-options-expected-to-pass
@@ -325,6 +328,8 @@
                     " predicate-read")
                   (when (:use-index opts)
                     " use-index")
+                  (when (:index-lookup-pushdown opts)
+                    " index-lookup-pushdown")
                   (when (:txn-mode opts)
                     (str " txn-mode " (:txn-mode opts)))
                   (when (:isolation opts)
@@ -516,6 +521,9 @@
     :default false]
 
    ["-i" "--use-index" "Whether to use indices, or read by primary key"
+    :default false]
+   
+   [nil, "--index-lookup-pushdown" "Whether to use the index and push down the index look up"
     :default false]
 
    ["-w" "--workload NAME" "Test workload to run"

--- a/tidb/src/tidb/monotonic.clj
+++ b/tidb/src/tidb/monotonic.clj
@@ -23,8 +23,10 @@
   ([c test k]
    (read-key c test k false))
   ([c test k lock?]
-   (-> (c/query c [(str "select (val) from cycle where "
-                        (if (:use-index test) "sk" "pk") " = ?" (when lock? " for update"))
+   (-> (c/query c [(str "select " 
+                        (if (:index-lookup-pushdown test) "/*+ index_lookup_pushdown(cycle, cycle_sk_val) */ val, val2" "(val)") 
+                        " from cycle where "
+                        (if (or (:use-index test) (:index-lookup-pushdown test)) "sk" "pk") " = ?" (when lock? " for update"))
                    k])
        first
        (:val -1))))
@@ -39,7 +41,7 @@
 
 (defn single-stmt-inc! [conn op]
   (let [k (:value op)
-        q (str "insert into cycle values (?, ?, 0) "
+        q (str "insert into cycle values (?, ?, 0, 1024) "
                "on duplicate key update val = values(val)+1")]
     (c/execute! conn [q k k] {:transaction? false})
     (assoc op :type :ok, :value {})))
@@ -54,8 +56,9 @@
       (c/execute! conn ["create table if not exists cycle
                         (pk  int not null primary key,
                          sk  int not null,
-                         val int)"])
-      (when (:use-index test)
+                         val int,
+                         val2 int)"])
+      (when (or (:use-index test) (:index-lookup-pushdown test))
         (c/create-index! conn ["create index cycle_sk_val on cycle (sk, val)"]))
       (when (:table-cache test)
         (c/execute! conn ["alter table cycle cache"]))))
@@ -85,7 +88,7 @@
                      (if (= -1 v)
                        (c/insert! c "cycle" {:pk k, :sk k, :val 0})
                        (c/update! c "cycle" {:val (inc v)},
-                                  [(str (if (:use-index test) "sk" "pk") " = ?")
+                                  [(str (if (or (:use-index test) (:index-lookup-pushdown test)) "sk" "pk") " = ?")
                                    k]))
                      ; The monotonic value constraint isn't actually enough to
                      ; capture all the ordering dependencies here: an increment

--- a/tidb/src/tidb/register.clj
+++ b/tidb/src/tidb/register.clj
@@ -21,8 +21,10 @@
 (defn read
   "Reads the current value of a key."
   [conn test k]
-  (:val (first (c/query conn [(str "select (val) from test where "
-                                   (if (:use-index test) "sk" "id") " = ? "
+  (:val (first (c/query conn [(str "select " 
+                                   (if (:index-lookup-pushdown test) "/*+ index_lookup_pushdown(test, test_sk_val) */ val, val2" "(val)")
+                                   " from test where "
+                                   (if (or (:use-index test) (:index-lookup-pushdown test)) "sk" "id") " = ? "
                                    (:read-lock test))
                               k]))))
 
@@ -37,8 +39,9 @@
       (c/execute! conn ["create table if not exists test
                         (id   int primary key,
                          sk   int,
-                         val  int)"])
-      (when (:use-index test)
+                         val  int,
+                         val2 int default 1024)"])
+      (when (or (:use-index test) (:index-lookup-pushdown test))
         (c/create-index! conn ["create index test_sk_val on test (sk, val)"]))
       (when (:table-cache test)
         (c/execute! conn ["alter table test cache"]))))

--- a/tidb/src/tidb/txn.clj
+++ b/tidb/src/tidb/txn.clj
@@ -10,20 +10,35 @@
   [i]
   (str "txn" i))
 
+(defn index-name
+  "Takes an integer and constructs a index name."
+  [i]
+  (str (table-name i) "_sk_val"))
+
 (defn table-for
   "What table should we use for the given key?"
   [table-count k]
   (table-name (mod (hash k) table-count)))
 
+(defn index-for
+  "What index name is for the given key?" 
+  [table-count k] 
+  (index-name (mod (hash k) table-count)))
+
 (defn mop!
   "Executes a transactional micro-op on a connection. Returns the completed
   micro-op."
   [conn test table-count [f k v]]
-  (let [table (table-for table-count k)]
+  (let [table (table-for table-count k) index (index-for table-count k)]
     [f k (case f
            :r (-> conn
-                  (c/query [(str "select val from " table " where "
+                  (c/query [(str "select " 
+                                 (if (:index-lookup-pushdown test) 
+                                   (str "/*+ index_lookup_pushdown(" table ", " index ") */ val, val2")
+                                   "val")
+                                 " from " table " where "
                                  (if (or (:use-index test)
+                                         (:index-lookup-pushdown test)
                                          (:predicate-read test))
                                    "sk"
                                    "id")
@@ -91,8 +106,9 @@
         (c/execute! conn [(str "create table if not exists " (table-name i)
                                " (id  int not null primary key,
                                sk  int not null,
-                               val " val-type ")")])
-        (when (:use-index test)
+                               val " val-type 
+                               " val2 int default 1024)")])
+        (when (or (:use-index test) (:index-lookup-pushdown test))
           (c/create-index! conn [(str "create index " (table-name i) "_sk_val on " (table-name i)
                                       " (sk, val" (when (= val-type "text") "(256)") ")")]))
         (when (:table-cache test)


### PR DESCRIPTION
1. Add a new option `--index-lookup-pushdown`, and if it is enabled, some table will use index lookup pushdown to query rows.
2. The index lookup push down table should add a new column `val2` because some extra row which cannot be found in the index is required in select statement.