### PR TITLE
support foreign-key test for bank workload

### DIFF
--- a/jepsen/src/jepsen/tests/bank.clj
+++ b/jepsen/src/jepsen/tests/bank.clj
@@ -48,6 +48,7 @@
   numbers mean more egregious errors."
   [test err]
   (case (:type err)
+    :non-zero-total-moved (Math/abs (float (:total-moved err)))
     :unexpected-key (count (:unexpected err))
     :nil-balance    (count (:nils err))
     :wrong-total    (Math/abs (float (/ (- (:total err) (:total-amount test))
@@ -57,8 +58,9 @@
 (defn check-op
   "Takes a single op and returns errors in its balance"
   [accts total negative-balances? op]
-  (let [ks       (keys (:value op))
-        balances (vals (:value op))]
+  (let [ks          (keys (:value op))
+        balances    (vals (:value op))
+        total-moved (or (:total-moved op) 0)]
     (cond (not-every? accts ks)
           {:type        :unexpected-key
            :unexpected  (remove accts ks)
@@ -75,6 +77,11 @@
           {:type     :wrong-total
            :total    (reduce + balances)
            :op       op}
+
+          (not (zero? total-moved))
+          {:type        :non-zero-total-moved
+           :total-moved total-moved
+           :op          op}
 
           (and (not negative-balances?) (some neg? balances))
           {:type     :negative-value

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -18,14 +18,14 @@
    :amount amount})
 
 (defn create-bank-records-table! [conn]
-  (c/execute! conn ["create table if not exists bank_records
+  (c/execute! conn ["create table if not exists records
                     (id         bigint not null auto_increment primary key,
                      account_id int    not null,
                      amount     bigint not null,
                      foreign key (account_id) references accounts(id))"]))
 
 (defn insert-bank-record! [conn {:keys [from to amount]}]
-  (c/execute! conn ["insert into bank_records(account_id, amount) values (?, ?), (?, ?)"
+  (c/execute! conn ["insert into records(account_id, amount) values (?, ?), (?, ?)"
                     from (- amount)
                     to amount]
               {:transaction? false}))
@@ -51,7 +51,7 @@
     (when (compare-and-set! tbl-created? false true)
       (c/with-conn-failure-retry conn
         (when (:test-foreign-key test)
-          (c/execute! conn ["drop table if exists bank_records"]))
+          (c/execute! conn ["drop table if exists records"]))
         (c/execute! conn ["drop table if exists accounts"])
         (c/execute! conn ["create table if not exists accounts
                           (id     int not null primary key,
@@ -78,53 +78,54 @@
   (invoke! [this test op]
     (if (and (= :transfer (:f op)) (:single-stmt-write test))
       (with-error-handling op (single-stmt-transfer! conn op))
-      (with-txn op [c conn {:isolation (util/isolation-level test)
-                            :before-hook (partial c/rand-init-txn! test conn)}]
-        (try
-          (case (:f op)
-            :read (let [accounts (->> (c/query c [(str "select * from accounts")])
-                                      (map (juxt :id :balance))
-                                      (into (sorted-map)))
-                        total-amount (when (:test-foreign-key test)
-                                       (->> (c/query c ["select sum(amount) as total_amount from bank_records"]
-                                                     {:row-fn :total_amount})
-                                            first))]
-                    (cond-> (assoc op :type :ok, :value accounts)
-                      (:test-foreign-key test) (assoc :total-amount total-amount)))
+      (do
+        (when (and (= :transfer (:f op)) (:test-foreign-key test))
+          (with-txn op [c conn {:isolation (util/isolation-level test)
+                                :before-hook (partial c/rand-init-txn! test conn)}]
+                                (let [{:keys [from to amount]} (:value op)]
+                                  (insert-bank-record! c {:from from :to to :amount amount}))))
 
-            :transfer
-            (let [{:keys [from to amount]} (:value op)
-                  b1 (-> c
-                         (c/query [(str "select * from accounts where id = ? "
-                                        (:read-lock test)) from]
-                                  {:row-fn :balance})
-                         first
-                         (- amount))
-                  b2 (-> c
-                         (c/query [(str "select * from accounts where id = ? "
-                                        (:read-lock test))
-                                   to]
-                                  {:row-fn :balance})
-                         first
-                         (+ amount))]
-              (cond (neg? b1)
-                    (assoc op :type :fail, :value [:negative from b1])
-                    (neg? b2)
-                    (assoc op :type :fail, :value [:negative to b2])
-                    true
-                    (if (:update-in-place test)
-                      (do (c/execute! c ["update accounts set balance = balance - ? where id = ?" amount from])
-                          (c/execute! c ["update accounts set balance = balance + ? where id = ?" amount to])
-                          (when (:test-foreign-key test) (with-txn op [c conn {:isolation (util/isolation-level test)
+        (with-txn op [c conn {:isolation (util/isolation-level test)
                             :before-hook (partial c/rand-init-txn! test conn)}]
-                            (insert-bank-record! c {:from from :to to :amount amount})))
-                          (assoc op :type :ok :value (transfer_value from to b1 b2 amount)))
-                      (do (c/update! c :accounts {:balance b1} ["id = ?" from])
-                          (c/update! c :accounts {:balance b2} ["id = ?" to])
-                          (when (:test-foreign-key test) (with-txn op [c conn {:isolation (util/isolation-level test)
-                            :before-hook (partial c/rand-init-txn! test conn)}]
-                            (insert-bank-record! c {:from from :to to :amount amount})))
-                          (assoc op :type :ok :value (transfer_value from to b1 b2 amount)))))))))))
+          (try
+            (case (:f op)
+              :read (let [accounts (->> (c/query c [(str "select * from accounts")])
+                                        (map (juxt :id :balance))
+                                        (into (sorted-map)))
+                          total-moved (when (:test-foreign-key test)
+                                        (->> (c/query c ["select sum(amount) as total_moved from records"]
+                                                      {:row-fn :total_moved})
+                                              first))]
+                      (cond-> (assoc op :type :ok, :value accounts)
+                        (:test-foreign-key test) (assoc :total-moved total-moved)))
+
+              :transfer
+              (let [{:keys [from to amount]} (:value op)
+                    b1 (-> c
+                          (c/query [(str "select * from accounts where id = ? "
+                                          (:read-lock test)) from]
+                                    {:row-fn :balance})
+                          first
+                          (- amount))
+                    b2 (-> c
+                          (c/query [(str "select * from accounts where id = ? "
+                                          (:read-lock test))
+                                    to]
+                                    {:row-fn :balance})
+                          first
+                          (+ amount))]
+                (cond (neg? b1)
+                      (assoc op :type :fail, :value [:negative from b1])
+                      (neg? b2)
+                      (assoc op :type :fail, :value [:negative to b2])
+                      true
+                      (if (:update-in-place test)
+                        (do (c/execute! c ["update accounts set balance = balance - ? where id = ?" amount from])
+                            (c/execute! c ["update accounts set balance = balance + ? where id = ?" amount to])
+                            (assoc op :type :ok :value (transfer_value from to b1 b2 amount)))
+                        (do (c/update! c :accounts {:balance b1} ["id = ?" from])
+                            (c/update! c :accounts {:balance b2} ["id = ?" to])
+                            (assoc op :type :ok :value (transfer_value from to b1 b2 amount))))))))))))
 
   (teardown! [_ test])
 

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -17,12 +17,27 @@
    :to     [to (- b2 amount) b2]
    :amount amount})
 
-(defn single-stmt-transfer! [conn op]
+(defn create-bank-records-table! [conn]
+  (c/execute! conn ["create table if not exists bank_records
+                    (id         bigint not null auto_increment primary key,
+                     account_id int    not null,
+                     amount     bigint not null,
+                     foreign key (account_id) references accounts(id))"]))
+
+(defn insert-bank-record! [conn {:keys [from to amount]}]
+  (c/execute! conn ["insert into bank_records(account_id, amount) values (?, ?), (?, ?)"
+                    from (- amount)
+                    to amount]
+              {:transaction? false}))
+
+(defn single-stmt-transfer! [conn test op]
   (let [{:keys [from to amount]} (:value op)]
     (c/execute! conn
                 ["update accounts set balance = balance + if(id=?,-?,?) where id=? or (id=? and 1/if(balance>=?,1,0))"
                  from amount amount to from amount]
                 {:transaction? false})
+    ;; (when (:test-foreign-key test)
+    ;;   (insert-bank-record! conn {:from from :to to :amount amount}))
     (attach-txn-info conn (assoc op :type :ok))))
 
 (defrecord BankClient [conn tbl-created?]
@@ -35,6 +50,8 @@
     ; requests per second; let's try to make its life easier
     (when (compare-and-set! tbl-created? false true)
       (c/with-conn-failure-retry conn
+        (when (:test-foreign-key test)
+          (c/execute! conn ["drop table if exists bank_records"]))
         (c/execute! conn ["drop table if exists accounts"])
         (c/execute! conn ["create table if not exists accounts
                           (id     int not null primary key,
@@ -54,7 +71,9 @@
                                          :balance (if (= a (first (:accounts test)))
                                                     (:total-amount test)
                                                     0)}))
-            (catch java.sql.SQLIntegrityConstraintViolationException e nil))))))
+            (catch java.sql.SQLIntegrityConstraintViolationException e nil)))
+        (when (:test-foreign-key test)
+          (create-bank-records-table! conn)))))
 
   (invoke! [this test op]
     (if (and (= :transfer (:f op)) (:single-stmt-write test))
@@ -63,10 +82,15 @@
                             :before-hook (partial c/rand-init-txn! test conn)}]
         (try
           (case (:f op)
-            :read (->> (c/query c [(str "select * from accounts")])
-                       (map (juxt :id :balance))
-                       (into (sorted-map))
-                       (assoc op :type :ok, :value))
+            :read (let [accounts (->> (c/query c [(str "select * from accounts")])
+                                      (map (juxt :id :balance))
+                                      (into (sorted-map)))
+                        total-amount (when (:test-foreign-key test)
+                                       (->> (c/query c ["select sum(amount) as total_amount from bank_records"]
+                                                     {:row-fn :total_amount})
+                                            first))]
+                    (cond-> (assoc op :type :ok, :value accounts)
+                      (:test-foreign-key test) (assoc :total-amount total-amount)))
 
             :transfer
             (let [{:keys [from to amount]} (:value op)
@@ -91,9 +115,15 @@
                     (if (:update-in-place test)
                       (do (c/execute! c ["update accounts set balance = balance - ? where id = ?" amount from])
                           (c/execute! c ["update accounts set balance = balance + ? where id = ?" amount to])
+                          (when (:test-foreign-key test) (with-txn op [c conn {:isolation (util/isolation-level test)
+                            :before-hook (partial c/rand-init-txn! test conn)}]
+                            (insert-bank-record! c {:from from :to to :amount amount})))
                           (assoc op :type :ok :value (transfer_value from to b1 b2 amount)))
                       (do (c/update! c :accounts {:balance b1} ["id = ?" from])
                           (c/update! c :accounts {:balance b2} ["id = ?" to])
+                          (when (:test-foreign-key test) (with-txn op [c conn {:isolation (util/isolation-level test)
+                            :before-hook (partial c/rand-init-txn! test conn)}]
+                            (insert-bank-record! c {:from from :to to :amount amount})))
                           (assoc op :type :ok :value (transfer_value from to b1 b2 amount)))))))))))
 
   (teardown! [_ test])

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -36,8 +36,6 @@
                 ["update accounts set balance = balance + if(id=?,-?,?) where id=? or (id=? and 1/if(balance>=?,1,0))"
                  from amount amount to from amount]
                 {:transaction? false})
-    ;; (when (:test-foreign-key test)
-    ;;   (insert-bank-record! conn {:from from :to to :amount amount}))
     (attach-txn-info conn (assoc op :type :ok))))
 
 (defrecord BankClient [conn tbl-created?]

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -76,15 +76,19 @@
   (invoke! [this test op]
     (if (and (= :transfer (:f op)) (:single-stmt-write test))
       (with-error-handling op (single-stmt-transfer! conn op))
-      (do
-        (when (and (= :transfer (:f op)) (:test-foreign-key test))
-          (with-txn op [c conn {:isolation (util/isolation-level test)
-                                :before-hook (partial c/rand-init-txn! test conn)}]
-                                (let [{:keys [from to amount]} (:value op)]
-                                  (insert-bank-record! c {:from from :to to :amount amount}))))
+      (let [op (if (and (= :transfer (:f op)) (:test-foreign-key test))
+                 (let [fk-op (with-txn op [c conn {:isolation (util/isolation-level test)
+                                                   :before-hook (partial c/rand-init-txn! test conn)}]
+                               (let [{:keys [from to amount]} (:value op)]
+                                 (insert-bank-record! c {:from from :to to :amount amount})
+                                 op))]
+                    ; the :txn-info from fk-op is attached as :fk-txn-info
+                    (cond-> op
+                      (:txn-info fk-op) (assoc :fk-txn-info (:txn-info fk-op)))) 
+                 op)]
 
         (with-txn op [c conn {:isolation (util/isolation-level test)
-                            :before-hook (partial c/rand-init-txn! test conn)}]
+                              :before-hook (partial c/rand-init-txn! test conn)}]
           (try
             (case (:f op)
               :read (let [accounts (->> (c/query c [(str "select * from accounts")])

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -320,6 +320,8 @@
                     " auto-retry")
                   (when (not= 0 (:auto-retry-limit opts))
                     (str " auto-retry-limit " (:auto-retry-limit opts)))
+                  (when (:test-foreign-key opts)
+                    " foreign-key")
                   (when (:update-in-place opts)
                     " update-in-place")
                   (when (:read-lock opts)
@@ -510,6 +512,9 @@
     :default false]
 
    [nil "--pd-services" "If true, run pd as mutiple micro services."
+    :default false]
+
+   [nil "--test-foreign-key" "Enable bank foreign key path."
     :default false]
 
    [nil "--single-stmt-write", "If true, performs write operations in a single statement when possible."


### PR DESCRIPTION
## Schame

```sql
CREATE TABLE accounts (
    id INT,
    balance INT NOT NULL,
    PRIMARY KEY (id)
);

CREATE TABLE records (
    id INT,
    account_id INT,
    amount INT NOT NULL,
    FOREIGN KEY (account_id) REFERENCES bank_accounts(id) ON DELETE CASCADE
);
```

## Transaction

A transaction is denoted by 2 db txns and 4 rows:
- txn1
  - Put: accounts(from, balance - amount)
  - Put: accounts(to, balance + amount)
- txn2
  - Insert: records(from, -amount)
  - Insert: records(to, amount)
 
## Verify
The verify checks 2 invariants:
- The sum of `accounts.balance` is fixed
- The sum of `records.amount` is 0

## Test

I ran a tiny test in my local machine, and it works well (error because I didn't install the plot utilities).

```bash
> lein run test --workload bank --time-limit 60 --test-count 1 --concurrency 2n --tarball-url='http://192.168.122.1:8080/tidb-shared-lock.tar.gz' --nemesis none --nodes n1,n2,n3 --os=image \
--test-foreign-key=true --txn-mode=pessimistic --read-lock=update
...
Errors occurred during analysis, but no anomalies found. ಠ~ಠ
```

Manually check the results:

```sql
MySQL [test]> select sum(balance) from accounts;
+--------------+
| sum(balance) |
+--------------+
|          100 |
+--------------+
1 row in set (0.001 sec)

MySQL [test]> select count(1), sum(amount) from records;
+----------+-------------+
| count(1) | sum(amount) |
+----------+-------------+
|      378 |           0 |
+----------+-------------+
1 row in set (0.004 sec)
```

A success transfer is printed as following (because the foreign key and main transfer are executed in 2 transactions, so another txn info is collected):

```clojure
{:type :ok, :f :transfer, :value {:from [3 27 26], :to [5 1 2], :amount 1}, :process 16, :time 19033938591,
:fk-txn-info {:txn_scope "global", :start_ts 462731203679879377, :commit_ts 462731203679879402, :txn_commit_mode "2pc", :async_commit_fallback false, :one_pc_fallback false, :pipelined false, :flush_wait_ms 0},
:txn-info {:txn_scope "global", :start_ts 462731203679879413, :commit_ts 462731203679879434, :txn_commit_mode "1pc", :async_commit_fallback false, :one_pc_fallback false, :pipelined false, :flush_wait_ms 0},
:index 17726}
```