### PR TITLE
ensure autocommit=1 for singel-stmt-write of comments

### DIFF
--- a/tidb/src/tidb/comments.clj
+++ b/tidb/src/tidb/comments.clj
@@ -61,10 +61,13 @@
   (invoke! [this test op]
     (case (:f op)
       :write (let [[k id] (:value op)
-                   table (id->table table-count id)]
+                   table (id->table table-count id)
+                   single-stmt-write? (:single-stmt-write test)]
                (c/rand-init-txn! test conn)
+               (when single-stmt-write?
+                 (c/set-auto-commit! conn true))
                (c/insert! conn table {:id id, :tkey k}
-                          {:transaction? (not (:single-stmt-write test))})
+                          {:transaction? (not single-stmt-write?)})
                (c/attach-txn-info conn (assoc op :type :ok)))
 
       :read (with-txn op [c conn {:isolation (util/isolation-level test)}]


### PR DESCRIPTION
Like https://github.com/pingcap/jepsen/pull/104, there is a chance that the previous txn failed to set autocommit back to 1, then the following single-stmt-writes run in an explicit txn (without commit).