### PR TITLE
Force close foreign key's transaction

### DIFF
--- a/jepsen/src/jepsen/util.clj
+++ b/jepsen/src/jepsen/util.clj
@@ -341,11 +341,6 @@
                      (throw (.getCause ee#))))]
      (if (= retval# ::timeout)
        (do (future-cancel worker#)
-           ; Wait until the worker actually finishes after cancellation.
-           (loop []
-             (when-not (future-done? worker#)
-               (Thread/sleep 1)
-               (recur)))
            ~timeout-val)
        retval#)))
 

--- a/jepsen/src/jepsen/util.clj
+++ b/jepsen/src/jepsen/util.clj
@@ -341,6 +341,11 @@
                      (throw (.getCause ee#))))]
      (if (= retval# ::timeout)
        (do (future-cancel worker#)
+           ; Wait until the worker actually finishes after cancellation.
+           (loop []
+             (when-not (future-done? worker#)
+               (Thread/sleep 1)
+               (recur)))
            ~timeout-val)
        retval#)))
 

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -81,9 +81,11 @@
                                (let [{:keys [from to amount]} (:value op)]
                                  (insert-bank-record! c {:from from :to to :amount amount})
                                  op))]
-                    ; the :txn-info from fk-op is attached as :fk-txn-info
-                    (cond-> op
-                      (:txn-info fk-op) (assoc :fk-txn-info (:txn-info fk-op))))
+                   ; set the auto-commit back to true after the foreign key txn
+                   (c/set-auto-commit! conn true)
+                   ; the :txn-info from fk-op is attached as :fk-txn-info
+                   (cond-> op
+                     (:txn-info fk-op) (assoc :fk-txn-info (:txn-info fk-op))))
                  op)]
 
         (with-txn op [c conn {:isolation (util/isolation-level test)

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -27,8 +27,7 @@
 (defn insert-bank-record! [conn {:keys [from to amount]}]
   (c/execute! conn ["insert into records(account_id, amount) values (?, ?), (?, ?)"
                     from (- amount)
-                    to amount]
-              {:transaction? false}))
+                    to amount]))
 
 (defn single-stmt-transfer! [conn test op]
   (let [{:keys [from to amount]} (:value op)]
@@ -84,7 +83,7 @@
                                  op))]
                     ; the :txn-info from fk-op is attached as :fk-txn-info
                     (cond-> op
-                      (:txn-info fk-op) (assoc :fk-txn-info (:txn-info fk-op)))) 
+                      (:txn-info fk-op) (assoc :fk-txn-info (:txn-info fk-op))))
                  op)]
 
         (with-txn op [c conn {:isolation (util/isolation-level test)


### PR DESCRIPTION
## What's changed

Because the foreign key transaction transfer operation contains 2 transactions, the fix #104 can not handle this case.

Force close foreign key's transaction after `with-txn` call. This avoids a remaining opened transaction.

## Root Cause

The foreign key case contains more conflict, and the transaction timeout may cause some weird execution order.

General log of jepsen bank:

```
[2025/12/11 03:11:07.790 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=0] ... [sql="SET @@SESSION.`autocommit`=0"]
[2025/12/11 03:11:07.791 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=0] ... [sql="insert into records(account_id, amount) values (7, -3), (1, 3)"]
[2025/12/11 03:11:27.725 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=462794959824617487] ... [sessionTxnMode=PESSIMISTIC] [sql="SELECT @@transaction_isolation"]
[2025/12/11 03:11:27.725 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=462794959824617487] ... [sessionTxnMode=PESSIMISTIC] [sql="SET @@SESSION.`tx_isolation`=_UTF8MB4'REPEATABLE-READ'"]
[2025/12/11 03:11:27.725 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=462794959824617487] ... [sessionTxnMode=PESSIMISTIC] [sql=ROLLBACK]
[2025/12/11 03:11:27.729 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=0] [forUpdateTS=0] ... [sql="select * from accounts where id = 7 FOR UPDATE"]

[2025/12/11 03:11:27.730 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=462794965041283095] ... [sessionTxnMode=PESSIMISTIC] [sql="SET @@SESSION.`autocommit`=1"]

[2025/12/11 03:11:27.732 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=0] [forUpdateTS=0] ... [sql="SET @@SESSION.`tx_isolation`=_UTF8MB4'REPEATABLE-READ'"]
[2025/12/11 03:11:27.732 +00:00] ... [GENERAL_LOG] [conn=3833593880] ... [txnStartTS=0] [forUpdateTS=0] ... [sql="select * from accounts where id = 1 FOR UPDATE"]
```


`SET @@SESSION.autocommit=1` is executed between 2 select-for-update statements and exit the transaction unexpectedly. And the following statements are executed in single auto-commit transactions, which break the invariants easily.

Jepsen never set variables between those 2 statements.

https://github.com/pingcap/jepsen/blob/dae83e6020806c7eb4962104715e8239e236c089/tidb/src/tidb/bank.clj#L106-L116

## Test

After this change, this type of invalid statement order is eliminated.
